### PR TITLE
Update itty-router example to use router.fetch signature export

### DIFF
--- a/samples/workers/itty/src/index.ts
+++ b/samples/workers/itty/src/index.ts
@@ -12,4 +12,4 @@ router.get('/hello', request => {
 
 router.all('*', () => error(404));
 
-export default { fetch: router.handle };
+export default router;


### PR DESCRIPTION
Recent `itty-router` versions have switched to using `router.fetch` (mirrored as `router.handle` for backwards compatibility) to allow for a direct export signature in Workers/Bun.

This PR reflects that change :)